### PR TITLE
[bug-fix] fix import and types' inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "ts",
     "typescript"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf package-lock.json dist build coverage node_modules",


### PR DESCRIPTION
`package.json` was using wrong paths from a previous version when there are no benchmark tests and `tst` folder was not included in root directories for tsc.

When you try to use package in code, then the IDE's TypeScript server accuses the module of having no types definition.
When you try to import it on node.js REPL the console reports that main entry does not exist.

This PR fixes it.